### PR TITLE
label social media icons correctly and make them be screen reader text

### DIFF
--- a/public/partials/divi-accessibility-embedded-css.php
+++ b/public/partials/divi-accessibility-embedded-css.php
@@ -79,12 +79,14 @@ if ( $this->can_load( 'screen_reader_text' ) ) {
 ?>
 .et_pb_contact_form_label,
 .widget_search .screen-reader-text,
+.et_pb_social_media_follow_network_name,
 .et_pb_search .screen-reader-text {
 	display: block !important; <?php // Reverse Divi adding display: none to screen reader text ?>
 }
 .da11y-screen-reader-text,
 .et_pb_contact_form_label,
 .widget_search .screen-reader-text,
+.et_pb_social_media_follow_network_name,
 .et_pb_search .screen-reader-text {
 	clip: rect(1px, 1px, 1px, 1px);
 	position: absolute !important;

--- a/public/partials/divi-accessibility-embedded-js.php
+++ b/public/partials/divi-accessibility-embedded-js.php
@@ -530,6 +530,24 @@ if ( $this->can_load( 'aria_hidden_icons' ) ) {
 			 * Add aria-hidden="true" to all icons
 			 */
 			$('#et_top_search, .et_close_search_field, .et_pb_main_blurb_image').attr('aria-hidden', 'true');
+
+            /**
+             * Correct labels on social media icons
+			 */
+			$('.et-social-facebook a.icon span').html("facebook");
+			$('.et-social-twitter a.icon span').html("twitter");
+			$('.et-social-google-plus a.icon span').html("google plus");
+			$('.et-social-pinterest a.icon span').html("pinterest");
+			$('.et-social-linkedin a.icona span').html("linked in");
+			$('.et-social-tumblr a.icon span').html("tumblr");
+            $('.et-social-instagram a.icon span').html("instagram");
+			$('.et-social-skype a.icon span').html("skype");
+			$('.et-social-flikr a.icon span').html("flickr");
+			$('.et-social-myspace a.icon span').html("my space");
+			$('.et-social-dribbble a.icon span').html("dribble");
+			$('.et-social-youtube a.icon span').html("you tube");
+			$('.et-social-vimeo a.icon span').html("vimeo");
+			$('.et-social-rss a.icon span').html("rss");
 		});
 	})(jQuery);
 	</script>


### PR DESCRIPTION
**Problem:** Social media icons ( `span.et_pb_social_media_follow_network_name`) by default have the text "Follow" as their contents, set to `display: none`. 

**Solution:** This PR adds those spans to the list of classes where screen reader text is being hidden incorrectly, _and_ it replaces their contents with the actual name of the social media service involved.

**Tested:** This PR was tested using Voice Over on Mac OSX Mojave.

**Notes:** 
* Yes, I know "Flickr" is spelled wrong in the class name. This is copied directly from Divi's own CSS. They spelled it wrong first. 
* Yes, I know I spelled "Dribbble" with only 2 B's and added spaces to some network names. I wanted to avoid any screen readers tripping over the unusual spellings.