### PR TITLE
Update aria_mobile_menu.js

### DIFF
--- a/public/partials/js/aria_mobile_menu.js
+++ b/public/partials/js/aria_mobile_menu.js
@@ -17,7 +17,7 @@ jQuery(document).ready(function($) {
 	*/
 	$('.mobile_menu_bar').keyup(function(event) {
 		if (event.keyCode === 13 || event.keyCode === 32) {
-			$('.mobile_menu_bar').click();
+			$(this).click();
 		}
 	});
 


### PR DESCRIPTION
This fixes keyboard accessibility of mobile hamburger menus when using the Divi Menu module or non-default Divi menus. Old code would click every hamburger icon on the page (and there are multiple), resulting in the mobile menu opening then immediately closing. This code only clicks the hamburger icon that you're on.